### PR TITLE
typo in entrypoint

### DIFF
--- a/listing_torchserve_models/Dockerfile
+++ b/listing_torchserve_models/Dockerfile
@@ -34,6 +34,6 @@ COPY config.properties /home/model-server/config.properties
 
 WORKDIR /home/model-server
 ENV TEMP=/home/model-server/tmp
-ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["serve"]
 


### PR DESCRIPTION
Entrypoint name was wrong because of the typo

Changed 'dockerd' to 'docker'


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
